### PR TITLE
Unit test updates

### DIFF
--- a/__tests__/components/DataRequirementsViewer/DataRequirementsFilters.test.tsx
+++ b/__tests__/components/DataRequirementsViewer/DataRequirementsFilters.test.tsx
@@ -18,18 +18,19 @@ const DATA_REQUIREMENT = [
 describe('DataRequirementsFiltersTab', () => {
   it('renders No Data inside filters tab with no data', () => {
     render(mantineRecoilWrap(<DataRequirementsFilters dataRequirements={undefined} />));
-    const JSONViewer = screen.getByText('No Data') as HTMLInputElement;
+    const JSONViewer = screen.getByText('No Data');
     expect(JSONViewer).toBeInTheDocument();
   });
+
   it('renders filters inside filters tab with data requirements passed in', () => {
     render(mantineRecoilWrap(<DataRequirementsFilters dataRequirements={DATA_REQUIREMENT} />));
-    expect(screen.getByText('_type') as HTMLInputElement).toBeInTheDocument();
-    expect(screen.getByText('Coverage') as HTMLInputElement).toBeInTheDocument();
-    expect(screen.getByText('_typeFilter') as HTMLInputElement).toBeInTheDocument();
+    expect(screen.getByText('_type')).toBeInTheDocument();
+    expect(screen.getByText('Coverage')).toBeInTheDocument();
+    expect(screen.getByText('_typeFilter')).toBeInTheDocument();
     expect(
       screen.getByText(
         'Coverage%3Ftype%3Ain=http%3A%2F%2Fcts.nlm.nih.gov%2Ffhir%2FValueSet%2F2.16.840.1.114222.4.11.3591'
-      ) as HTMLInputElement
+      )
     ).toBeInTheDocument();
   });
 });

--- a/__tests__/components/DataRequirementsViewer/DataRequirementsJSON.test.tsx
+++ b/__tests__/components/DataRequirementsViewer/DataRequirementsJSON.test.tsx
@@ -1,21 +1,69 @@
 import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { mantineRecoilWrap, mockResizeObserver } from '../../helpers/testHelpers';
 import DataRequirementsJSON from '../../../components/DataRequirementsView/DataRequirementsJSON';
 
-import '@testing-library/jest-dom';
+const EXAMPLE_DATA_REQUIREMENTS: fhir4.Library = {
+  resourceType: 'Library',
+  type: {
+    coding: [
+      {
+        code: 'module-definition',
+        system: 'http://terminology.hl7.org/CodeSystem/library-type'
+      }
+    ]
+  },
+  status: 'unknown',
+  dataRequirement: [
+    {
+      type: 'Coverage',
+      codeFilter: [
+        {
+          path: 'type',
+          valueSet: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591'
+        }
+      ]
+    }
+  ]
+};
+
+const EXAMPLE_ERROR: fhir4.OperationOutcome = {
+  resourceType: 'OperationOutcome',
+  issue: []
+};
 
 describe('DataRequirementsJSON tab', () => {
   // Workaround for issues with the built-in use-resize-observer in jest
   window.ResizeObserver = mockResizeObserver;
-  it('renders No Data inside with no data', () => {
+
+  it('should render "No Data" inside with no data', () => {
     render(mantineRecoilWrap(<DataRequirementsJSON isLoading={false} dataRequirements={null} error={null} />));
-    const JSONViewer = screen.getByText('No Data') as HTMLInputElement;
+    const JSONViewer = screen.getByText('No Data');
     expect(JSONViewer).toBeInTheDocument();
   });
-  it('renders spinner inside when loading', () => {
+
+  it('should render spinner inside when loading', () => {
     render(mantineRecoilWrap(<DataRequirementsJSON isLoading={true} dataRequirements={null} error={null} />));
     // The spinner component has role "presentation"
-    const JSONSpinner = screen.getByRole('presentation') as HTMLInputElement;
+    const JSONSpinner = screen.getByRole('presentation');
     expect(JSONSpinner).toBeInTheDocument();
+  });
+
+  it('should render data requirements content when provided', () => {
+    render(
+      mantineRecoilWrap(
+        <DataRequirementsJSON isLoading={false} dataRequirements={EXAMPLE_DATA_REQUIREMENTS} error={null} />
+      )
+    );
+
+    const jsonView = screen.getByTestId('prism-dr-content');
+    expect(jsonView).toBeInTheDocument();
+  });
+
+  it('should render OperationOutcome when error is encountered', () => {
+    render(mantineRecoilWrap(<DataRequirementsJSON isLoading={false} dataRequirements={null} error={EXAMPLE_ERROR} />));
+
+    const errorView = screen.getByTestId('prism-error-content');
+    expect(errorView).toBeInTheDocument();
   });
 });

--- a/__tests__/components/DataRequirementsViewer/DataRequirementsPanel.test.tsx
+++ b/__tests__/components/DataRequirementsViewer/DataRequirementsPanel.test.tsx
@@ -1,19 +1,93 @@
-import { render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { mantineRecoilWrap, mockResizeObserver } from '../../helpers/testHelpers';
+import {
+  getMockFetchImplementation,
+  getMockRecoilState,
+  mantineRecoilWrap,
+  mockResizeObserver
+} from '../../helpers/testHelpers';
 import DataRequirementsPanel from '../../../components/DataRequirementsView/DataRequirementsPanel';
+import { selectedMeasureState } from '../../../state/atoms/selectedMeasure';
+
+const EXAMPLE_MEASURE_ID = 'example-measure-id';
+const EXAMPLE_DATA_REQUIREMENTS: fhir4.Library = {
+  resourceType: 'Library',
+  type: {
+    coding: [
+      {
+        code: 'module-definition',
+        system: 'http://terminology.hl7.org/CodeSystem/library-type'
+      }
+    ]
+  },
+  status: 'unknown',
+  dataRequirement: [
+    {
+      type: 'Coverage',
+      codeFilter: [
+        {
+          path: 'type',
+          valueSet: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591'
+        }
+      ]
+    }
+  ]
+};
 
 describe('DataRequirementsPanel', () => {
   // Workaround for issues with the built-in use-resize-observer in jest
   window.ResizeObserver = mockResizeObserver;
-  it('renders a JSON tab', () => {
-    render(mantineRecoilWrap(<DataRequirementsPanel />));
-    const JSONTab = screen.getByRole('tab', { name: 'JSON' }) as HTMLInputElement;
-    expect(JSONTab).toBeInTheDocument();
+  beforeAll(() => {
+    global.fetch = getMockFetchImplementation(EXAMPLE_DATA_REQUIREMENTS);
   });
-  it('renders a Filters tab', () => {
+
+  it('should render tab list', () => {
     render(mantineRecoilWrap(<DataRequirementsPanel />));
-    const FilterTab = screen.getByRole('tab', { name: 'Filters' }) as HTMLInputElement;
-    expect(FilterTab).toBeInTheDocument();
+
+    const tabs = screen.getByRole('tablist');
+
+    const JSONTab = within(tabs).getByRole('tab', { name: 'JSON' });
+    expect(JSONTab).toBeInTheDocument();
+
+    const filterTab = within(tabs).getByRole('tab', { name: 'Filters' });
+    expect(filterTab).toBeInTheDocument();
+  });
+
+  it('should switch tabs on click', async () => {
+    render(mantineRecoilWrap(<DataRequirementsPanel />));
+
+    const tabs = screen.getByRole('tablist');
+
+    const filterTab = within(tabs).getByRole('tab', { name: 'Filters' }) as HTMLButtonElement;
+    const JSONTab = within(tabs).getByRole('tab', { name: 'JSON' }) as HTMLButtonElement;
+
+    fireEvent.click(filterTab);
+
+    expect(filterTab).toHaveAttribute('aria-selected', 'true');
+    expect(JSONTab).toHaveAttribute('aria-selected', 'false');
+
+    fireEvent.click(JSONTab);
+
+    expect(filterTab).toHaveAttribute('aria-selected', 'false');
+    expect(JSONTab).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('should render data requirements when fetched', async () => {
+    const HardcodedRecoilMeasureState = getMockRecoilState(selectedMeasureState, { id: EXAMPLE_MEASURE_ID });
+
+    await act(async () => {
+      render(
+        mantineRecoilWrap(
+          <>
+            <HardcodedRecoilMeasureState />
+            <DataRequirementsPanel />
+          </>
+        )
+      );
+    });
+
+    const noDataContent = screen.queryByText(/No Data/);
+
+    expect(noDataContent).not.toBeInTheDocument();
   });
 });

--- a/__tests__/components/KickoffRequestView/KickoffBody.test.tsx
+++ b/__tests__/components/KickoffRequestView/KickoffBody.test.tsx
@@ -9,7 +9,7 @@ describe('KickoffBody', () => {
 
   it('renders with "No Data" message when there is no body preview to show', async () => {
     render(mantineRecoilWrap(<KickoffBody body={undefined} />));
-    const noDataText = await screen.getByText('No Data');
+    const noDataText = screen.getByText('No Data');
     expect(noDataText).toBeInTheDocument();
   });
 

--- a/__tests__/components/MeasureSelect.test.tsx
+++ b/__tests__/components/MeasureSelect.test.tsx
@@ -1,0 +1,142 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { render, screen, fireEvent, act, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {
+  getMockFetchImplementation,
+  getMockFetchImplementationError,
+  mantineRecoilWrap,
+  mockResizeObserver
+} from '../helpers/testHelpers';
+import MeasureSelect from '../../components/MeasureSelect';
+
+const exampleMeasureWithName: fhir4.Measure = {
+  resourceType: 'Measure',
+  status: 'draft',
+  url: 'http://example.com/Measure/example-measure-id',
+  id: 'example-measure-with-name',
+  name: 'example-measure-name'
+};
+
+const exampleMeasureWithoutName: fhir4.Measure = {
+  resourceType: 'Measure',
+  status: 'draft',
+  url: 'http://example.com/Measure/example-measure-id',
+  id: 'example-measure-without-name'
+};
+
+const bundleWithMeasure: fhir4.Bundle = {
+  resourceType: 'Bundle',
+  type: 'searchset',
+  entry: [
+    {
+      resource: exampleMeasureWithName
+    },
+    {
+      resource: exampleMeasureWithoutName
+    }
+  ]
+};
+
+describe('MeasureSelect', () => {
+  // Workaround for issues with the built-in use-resize-observer in jest
+  window.ResizeObserver = mockResizeObserver;
+
+  describe('ok response tests', () => {
+    beforeAll(() => {
+      global.fetch = getMockFetchImplementation(bundleWithMeasure);
+    });
+
+    it('should render select box', async () => {
+      await act(async () => {
+        render(mantineRecoilWrap(<MeasureSelect />));
+      });
+
+      const select = screen.getByPlaceholderText('Measure ID') as HTMLInputElement;
+
+      expect(select).toBeInTheDocument();
+    });
+
+    it('should should render an option with measure from response', async () => {
+      await act(async () => {
+        render(mantineRecoilWrap(<MeasureSelect />));
+      });
+
+      const select = screen.getByPlaceholderText('Measure ID') as HTMLInputElement;
+
+      await act(async () => {
+        fireEvent.click(select);
+      });
+
+      const options = screen.getAllByRole('option') as HTMLOptionElement[];
+
+      expect(options).toBeDefined();
+      expect(options).toHaveLength(2);
+      expect(options[0]).toBeInTheDocument();
+      expect((options[0].attributes as any).url.value).toEqual(exampleMeasureWithName.url);
+    });
+
+    it('should update selected value to measure ID', async () => {
+      await act(async () => {
+        render(mantineRecoilWrap(<MeasureSelect />));
+      });
+
+      const select = screen.getByPlaceholderText('Measure ID') as HTMLInputElement;
+
+      expect(select.value).toEqual('');
+
+      await act(async () => {
+        fireEvent.change(select, { target: { value: exampleMeasureWithName.id } });
+      });
+
+      expect(select.value).toEqual(exampleMeasureWithName.id);
+    });
+
+    it('should display id and name when provided', async () => {
+      await act(async () => {
+        render(mantineRecoilWrap(<MeasureSelect />));
+      });
+
+      const select = screen.getByPlaceholderText('Measure ID') as HTMLInputElement;
+
+      await act(async () => {
+        fireEvent.click(select);
+      });
+
+      const text = screen.getByText(`${exampleMeasureWithName.name} (${exampleMeasureWithName.id})`);
+      expect(text).toBeInTheDocument();
+    });
+
+    it('should default to display id when name is absent', async () => {
+      await act(async () => {
+        render(mantineRecoilWrap(<MeasureSelect />));
+      });
+
+      const select = screen.getByPlaceholderText('Measure ID') as HTMLInputElement;
+
+      await act(async () => {
+        fireEvent.click(select);
+      });
+
+      const text = screen.getByText(`${exampleMeasureWithoutName.id}`);
+      expect(text).toBeInTheDocument();
+    });
+  });
+
+  describe('error response tests', () => {
+    beforeAll(() => {
+      global.fetch = getMockFetchImplementationError('example error');
+    });
+
+    it('should show error notification for bad response', async () => {
+      await act(async () => {
+        render(mantineRecoilWrap(<MeasureSelect />));
+      });
+
+      const errorNotif = screen.getByRole('alert') as HTMLDivElement;
+      expect(errorNotif).toBeInTheDocument();
+
+      const errorMessage = within(errorNotif).getByText(/example error/);
+      expect(errorMessage).toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/components/ResetInputsButton.test.tsx
+++ b/__tests__/components/ResetInputsButton.test.tsx
@@ -1,12 +1,46 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { mantineRecoilWrap } from '../helpers/testHelpers';
+import { getMockRecoilState, getRecoilObserver, mantineRecoilWrap } from '../helpers/testHelpers';
 import ResetInputsButton from '../../components/ResetInputsButton';
+import { selectedMeasureState } from '../../state/atoms/selectedMeasure';
+import { exportUrlState } from '../../state/atoms/exportUrl';
 
 describe('ResetInputButtons', () => {
   it('renders a button to reset inputs', () => {
     render(mantineRecoilWrap(<ResetInputsButton />));
     const resetButton = screen.getByText('Reset Inputs');
     expect(resetButton).toBeInTheDocument();
+  });
+
+  it('should reset inputs when clicked', () => {
+    const measureStateChange = jest.fn();
+    const urlStateChange = jest.fn();
+
+    const MeasureRecoilObserver = getRecoilObserver(selectedMeasureState, measureStateChange);
+    const MeasureRecoilState = getMockRecoilState(selectedMeasureState, { id: 'test-measure' });
+    const UrlRecoilState = getMockRecoilState(exportUrlState, 'http://example.com');
+    const UrlRecoilStateObserver = getRecoilObserver(exportUrlState, urlStateChange);
+
+    render(
+      mantineRecoilWrap(
+        <>
+          <MeasureRecoilState />
+          <MeasureRecoilObserver />
+          <UrlRecoilState />
+          <UrlRecoilStateObserver />
+          <ResetInputsButton />
+        </>
+      )
+    );
+
+    const resetButton = screen.getByText('Reset Inputs');
+
+    fireEvent.click(resetButton);
+
+    // Called once on render, once on mock state initialization, once more on reset
+    expect(measureStateChange).toHaveBeenCalledTimes(3);
+    expect(measureStateChange).toHaveBeenCalledWith(null);
+    expect(urlStateChange).toHaveBeenCalledTimes(3);
+    expect(urlStateChange).toHaveBeenCalledWith('');
   });
 });

--- a/__tests__/helpers/testHelpers.tsx
+++ b/__tests__/helpers/testHelpers.tsx
@@ -1,6 +1,8 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { ColorSchemeProvider, MantineProvider } from '@mantine/core';
 import { NotificationsProvider } from '@mantine/notifications';
-import { RecoilRoot } from 'recoil';
+import { useEffect } from 'react';
+import { RecoilRoot, RecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 
 export function mantineRecoilWrap(children: JSX.Element) {
   return (
@@ -24,3 +26,49 @@ export const mockResizeObserver = jest.fn().mockImplementation(() => ({
   unobserve: jest.fn(),
   disconnect: jest.fn()
 }));
+
+/*
+ * Generate a mock implementation for `fetch` with any desired 200 OK response
+ * Use any type to avoid writing out every property of `fetch` responses
+ */
+export function getMockFetchImplementation(desiredResponse: any) {
+  return jest.fn(
+    () =>
+      Promise.resolve({
+        json: jest.fn().mockResolvedValue(desiredResponse)
+      }) as any
+  );
+}
+
+/*
+ * Generate a mock implementation that rejects a `fetch` call with a specific error
+ */
+export function getMockFetchImplementationError(errorMessage: string) {
+  return jest.fn(() => Promise.reject(new Error(errorMessage)));
+}
+
+/*
+ * Generate a functional component that can hardcode the value of a recoil atom
+ */
+export function getMockRecoilState<T>(atom: RecoilState<T>, value: T) {
+  return () => {
+    const setMockState = useSetRecoilState(atom);
+    useEffect(() => {
+      setMockState(value);
+    }, [setMockState]);
+    return null;
+  };
+}
+
+/*
+ * Generate a functional component that can observe changes to a recoil atom
+ */
+export function getRecoilObserver<T>(atom: RecoilState<T>, onChange: (value: T) => void) {
+  return () => {
+    const value = useRecoilValue(atom);
+    useEffect(() => {
+      onChange(value);
+    }, [value]);
+    return null;
+  };
+}

--- a/components/DataRequirementsView/DataRequirementsJSON.tsx
+++ b/components/DataRequirementsView/DataRequirementsJSON.tsx
@@ -33,9 +33,17 @@ function renderJSONResults(
       </Center>
     );
   } else if (error) {
-    return <Prism language="json">{JSON.stringify(error, undefined, 2)}</Prism>;
+    return (
+      <Prism data-testid="prism-error-content" language="json">
+        {JSON.stringify(error, undefined, 2)}
+      </Prism>
+    );
   } else if (dataRequirements) {
-    return <Prism language="json">{JSON.stringify(dataRequirements, undefined, 2)}</Prism>;
+    return (
+      <Prism data-testid="prism-dr-content" language="json">
+        {JSON.stringify(dataRequirements, undefined, 2)}
+      </Prism>
+    );
   } else {
     return (
       <Center>


### PR DESCRIPTION
## Summary

This PR adds helpers and tests for mocking http calls made with fetch to deqm-test-server. I also added helpers for observing and/or hardcoding recoil state values to allow for better testing with them in the future (e.g. the data requirements panel depended on the selected measure state, which I could hardcode to a specific value in order to test a better branch of that component).

### New Behavior

More tests

### Code Changes

* Added reusable functions in test helpers to use mock fetch 200 values or error values, as well as recoil observer and hardcoder
* Expand tests for all components to test more functionality
* Remove some unnecessary/incorrect casts of `HTMLInputElement`. We should only do this when we know the results of the `getBy*` calls and need to do something with it.

## Testing Guidance

Tests