### PR TITLE
Measure Dropdown Loading Spinner and Error on No Measures

### DIFF
--- a/__tests__/components/MeasureSelect.test.tsx
+++ b/__tests__/components/MeasureSelect.test.tsx
@@ -38,6 +38,12 @@ const bundleWithMeasure: fhir4.Bundle = {
   ]
 };
 
+const bundleWithNoMeasures: fhir4.Bundle = {
+  resourceType: 'Bundle',
+  type: 'searchset',
+  entry: []
+};
+
 describe('MeasureSelect', () => {
   // Workaround for issues with the built-in use-resize-observer in jest
   window.ResizeObserver = mockResizeObserver;
@@ -177,6 +183,26 @@ describe('MeasureSelect', () => {
       expect(errorMessage).toBeInTheDocument();
 
       // spinner should no longer exist
+      const loading = screen.queryByRole('presentation');
+      expect(loading).not.toBeInTheDocument();
+    });
+  });
+
+  describe('empty measure list tests', () => {
+    beforeAll(() => {
+      global.fetch = getMockFetchImplementation(bundleWithNoMeasures);
+    });
+
+    it('should show error notification for bad response', async () => {
+      await act(async () => {
+        render(mantineRecoilWrap(<MeasureSelect />));
+      });
+
+      const select = screen.getByPlaceholderText('No Measures Found') as HTMLInputElement;
+      expect(select).toBeInTheDocument();
+      expect(select).toBeInvalid();
+
+      // spinner should not exist
       const loading = screen.queryByRole('presentation');
       expect(loading).not.toBeInTheDocument();
     });

--- a/__tests__/helpers/testHelpers.tsx
+++ b/__tests__/helpers/testHelpers.tsx
@@ -41,6 +41,24 @@ export function getMockFetchImplementation(desiredResponse: any) {
 }
 
 /*
+ * Generate a mock implementation for `fetch` with any desired 200 OK response
+ * Adds a delay before resolving the request
+ * Use any type to avoid writing out every property of `fetch` responses
+ */
+export function getMockSlowFetchImplementation(desiredResponse: any, delay: number) {
+  return jest.fn(
+    () =>
+      new Promise(resolve => {
+        setTimeout(() => {
+          resolve({
+            json: jest.fn().mockResolvedValue(desiredResponse)
+          });
+        }, delay);
+      }) as any
+  );
+}
+
+/*
  * Generate a mock implementation that rejects a `fetch` call with a specific error
  */
 export function getMockFetchImplementationError(errorMessage: string) {

--- a/components/MeasureSelect.tsx
+++ b/components/MeasureSelect.tsx
@@ -1,4 +1,4 @@
-import { Select, SelectItem } from '@mantine/core';
+import { Loader, Select, SelectItem } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
 import { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
@@ -10,6 +10,7 @@ export default function MeasureSelect() {
   const [selectedMeasure, setSelectedMeasure] = useRecoilState<{ id: string; url?: string } | null>(
     selectedMeasureState
   );
+  const [isLoading, setIsLoading] = useState<boolean>(true);
 
   useEffect(() => {
     fetch(`${process.env.NEXT_PUBLIC_DEQM_SERVER}/Measure`)
@@ -25,8 +26,10 @@ export default function MeasureSelect() {
             };
           }) ?? [];
         setMeasures(measureItems);
+        setIsLoading(false);
       })
       .catch((reason: Error) => {
+        setIsLoading(false);
         showNotification({
           title: 'FHIR Server Error',
           message: `Measure listing failed: ${reason.message}. Check if deqm-test-server is running.`,
@@ -47,6 +50,7 @@ export default function MeasureSelect() {
         const measure = measures.find(m => m.value === measureId) as SelectItem;
         setSelectedMeasure({ id: measure.value, url: measure.url });
       }}
+      rightSection={isLoading ? <Loader size={'sm'} /> : null}
     />
   );
 }

--- a/components/MeasureSelect.tsx
+++ b/components/MeasureSelect.tsx
@@ -11,6 +11,7 @@ export default function MeasureSelect() {
     selectedMeasureState
   );
   const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [hasNoMeasures, setHasNoMeasures] = useState<boolean>(false);
 
   useEffect(() => {
     fetch(`${process.env.NEXT_PUBLIC_DEQM_SERVER}/Measure`)
@@ -25,7 +26,11 @@ export default function MeasureSelect() {
               url: measure.url
             };
           }) ?? [];
-        setMeasures(measureItems);
+        if (measureItems.length === 0) {
+          setHasNoMeasures(true);
+        } else {
+          setMeasures(measureItems);
+        }
         setIsLoading(false);
       })
       .catch((reason: Error) => {
@@ -43,7 +48,8 @@ export default function MeasureSelect() {
 
   return (
     <Select
-      placeholder="Measure ID"
+      placeholder={hasNoMeasures ? 'No Measures Found' : 'Measure ID'}
+      error={hasNoMeasures ? <></> : undefined}
       data={measures}
       value={selectedMeasure ? selectedMeasure.id : ''}
       onChange={measureId => {


### PR DESCRIPTION
## Summary
Adds spinner to measure list while loading. Shows error when there are no measures.

### New Behavior
Adds a loading spinner to the measure dropdown for when it is waiting for the response from the FHIR server. Marks the dropdown as 'errored/invalid' and changes the placeholder to "No Measures Found" if there are no measures on the server.

### Code Changes
Added states to the MeasureSelect component to track the loading and no measure case. Made use of the `error` property to denote errors. Used `rightSection` property to put in a Mantine Loader component when waiting on the server.

Added unit tests to check the empty measure list case and tests for the loading spinner. Added a helper function to create a mock `fetch` that waits a given amount of time in milliseconds before resolving.

## Testing Guidance
- Loader spinner may disappear too quickly to see. But throttling in the chrome dev tools may allow you to see it.
- Empty and start deqm-test-server `npm run db:reset`
- Start demo app, measure dropdown should say "No Measures Found" and should have red outline and text.
