### PR TITLE
Url validation

### DIFF
--- a/__tests__/components/ExportURLInput.test.tsx
+++ b/__tests__/components/ExportURLInput.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { mantineRecoilWrap } from '../helpers/testHelpers';
 import ExportURLInput from '../../components/ExportURLInput';
+// import KickoffBody from '../../components/KickoffRequestView/KickoffBody'
 
 describe('ExportURLInput', () => {
   it('renders a text input field', () => {
@@ -12,5 +13,16 @@ describe('ExportURLInput', () => {
 
     fireEvent.change(textbox, { target: { value: 'http://localhost:3001/' } });
     expect(textbox.value).toBe('http://localhost:3001/');
+  });
+
+  it('renders an error for an invalid URL', () => {
+    render(mantineRecoilWrap(<ExportURLInput />));
+
+    const textbox = screen.getByPlaceholderText('Export URL (Data Source)') as HTMLInputElement;
+    expect(textbox).toBeInTheDocument();
+
+    fireEvent.change(textbox, { target: { value: 'invalid' } });
+    expect(textbox.value).toBe('invalid');
+    expect(textbox).toBeInvalid();
   });
 });

--- a/__tests__/components/ExportURLInput.test.tsx
+++ b/__tests__/components/ExportURLInput.test.tsx
@@ -2,7 +2,6 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { mantineRecoilWrap } from '../helpers/testHelpers';
 import ExportURLInput from '../../components/ExportURLInput';
-// import KickoffBody from '../../components/KickoffRequestView/KickoffBody'
 
 describe('ExportURLInput', () => {
   it('renders a text input field', () => {

--- a/__tests__/components/ExportURLInput.test.tsx
+++ b/__tests__/components/ExportURLInput.test.tsx
@@ -12,6 +12,7 @@ describe('ExportURLInput', () => {
 
     fireEvent.change(textbox, { target: { value: 'http://localhost:3001/' } });
     expect(textbox.value).toBe('http://localhost:3001/');
+    expect(textbox).toBeValid();
   });
 
   it('renders an error for an invalid URL', () => {

--- a/__tests__/components/ResetInputsButton.test.tsx
+++ b/__tests__/components/ResetInputsButton.test.tsx
@@ -1,9 +1,10 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { getMockRecoilState, getRecoilObserver, mantineRecoilWrap } from '../helpers/testHelpers';
 import ResetInputsButton from '../../components/ResetInputsButton';
 import { selectedMeasureState } from '../../state/atoms/selectedMeasure';
 import { exportUrlState } from '../../state/atoms/exportUrl';
+import ExportURLInput from '../../components/ExportURLInput';
 
 describe('ResetInputButtons', () => {
   it('renders a button to reset inputs', () => {
@@ -12,13 +13,13 @@ describe('ResetInputButtons', () => {
     expect(resetButton).toBeInTheDocument();
   });
 
-  it('should reset inputs when clicked', () => {
+  it('should reset inputs when clicked', async () => {
     const measureStateChange = jest.fn();
     const urlStateChange = jest.fn();
 
     const MeasureRecoilObserver = getRecoilObserver(selectedMeasureState, measureStateChange);
     const MeasureRecoilState = getMockRecoilState(selectedMeasureState, { id: 'test-measure' });
-    const UrlRecoilState = getMockRecoilState(exportUrlState, 'http://example.com');
+    const UrlRecoilState = getMockRecoilState(exportUrlState, {url:'http://example.com', valid: true});
     const UrlRecoilStateObserver = getRecoilObserver(exportUrlState, urlStateChange);
 
     render(
@@ -29,18 +30,34 @@ describe('ResetInputButtons', () => {
           <UrlRecoilState />
           <UrlRecoilStateObserver />
           <ResetInputsButton />
+          <ExportURLInput />
         </>
       )
     );
 
     const resetButton = screen.getByText('Reset Inputs');
+    const textbox = screen.getByPlaceholderText('Export URL (Data Source)') as HTMLInputElement;
+
+    // Create inputs
+    await act(async () => {
+      fireEvent.change(textbox, { target: { value: 'http://localhost:3001/' } });
+    });
+    expect(textbox.value).toBe('http://localhost:3001/');
+
 
     fireEvent.click(resetButton);
 
     // Called once on render, once on mock state initialization, once more on reset
     expect(measureStateChange).toHaveBeenCalledTimes(3);
     expect(measureStateChange).toHaveBeenCalledWith(null);
-    expect(urlStateChange).toHaveBeenCalledTimes(3);
-    expect(urlStateChange).toHaveBeenCalledWith('');
+    // Called another time for enteredURL
+    expect(urlStateChange).toHaveBeenCalledTimes(4);
+    expect(urlStateChange).toHaveBeenCalledWith( {
+      url: '',
+      valid: true
+    });
+
+    // expect exportUrl textbox and measure select to be empty
+    expect(textbox.value).toBe('');
   });
 });

--- a/__tests__/components/ResetInputsButton.test.tsx
+++ b/__tests__/components/ResetInputsButton.test.tsx
@@ -59,5 +59,6 @@ describe('ResetInputButtons', () => {
 
     // expect exportUrl textbox and measure select to be empty
     expect(textbox.value).toBe('');
+    expect(textbox).toBeValid();
   });
 });

--- a/components/ExportURLInput.tsx
+++ b/components/ExportURLInput.tsx
@@ -4,45 +4,31 @@ import { useRecoilState } from 'recoil';
 
 export default function ExportURLInput() {
   const [exportURL, setExportURL] = useRecoilState(exportUrlState);
-  
-  function checkURL(urlStr: string) {
-    // This is a bit more debated than I expected. I think we need port matching, so this regex might work from comments here: 
-    // https://stackoverflow.com/questions/161738/what-is-the-best-regular-expression-to-check-if-a-string-is-a-valid-url
-    // does not require http protocol
-    // const regex = new RegExp(/((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+(:[0-9]+)?|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))?)/);
-    // make boolean
-    // (TODO: don't allow spaces?)
-    // return !!urlStr.match(regex);
 
-    // non-regex approach - depends on what we're trying to match on, but this seems more consistent
-    // https://stackoverflow.com/questions/5717093/check-if-a-javascript-string-is-a-url
-    // requires http protocol
+  function checkURL(urlStr: string) {
     let url;
     try {
       url = new URL(urlStr);
     } catch (_) {
-      return false;  
+      return false;
     }
     // additional regex check for url non-allowed characters
     const regex = new RegExp(/[^-\]_.~!*'();:@&=+$,\/?%#[A-z0-9]/);
-    return (url.protocol === "http:" || url.protocol === "https:") && !urlStr.match(regex);
+    return (url.protocol === 'http:' || url.protocol === 'https:') && !urlStr.match(regex);
   }
-
 
   return (
     <TextInput
       placeholder="Export URL (Data Source)"
       value={exportURL.url}
-      onChange={
-        (event) => {
-          const valid = checkURL(event.currentTarget.value);
-          setExportURL({
-              url: event.currentTarget.value,
-              valid: valid
-            });
-        }
-      }
-      error={exportURL.valid ? undefined : <>Valid URL required</> }
+      onChange={event => {
+        const valid = checkURL(event.currentTarget.value);
+        setExportURL({
+          url: event.currentTarget.value,
+          valid: valid
+        });
+      }}
+      error={exportURL.valid ? undefined : <>Valid URL required</>}
     />
   );
 }

--- a/components/ExportURLInput.tsx
+++ b/components/ExportURLInput.tsx
@@ -23,7 +23,9 @@ export default function ExportURLInput() {
     } catch (_) {
       return false;  
     }
-    return url.protocol === "http:" || url.protocol === "https:";
+    // additional regex check for url non-allowed characters
+    const regex = new RegExp(/[^-\]_.~!*'();:@&=+$,\/?%#[A-z0-9]/);
+    return (url.protocol === "http:" || url.protocol === "https:") && !urlStr.match(regex);
   }
 
 

--- a/components/ExportURLInput.tsx
+++ b/components/ExportURLInput.tsx
@@ -1,14 +1,55 @@
 import { TextInput } from '@mantine/core';
 import { exportUrlState } from '../state/atoms/exportUrl';
+import { useState } from 'react';
 import { useRecoilState } from 'recoil';
 
 export default function ExportURLInput() {
   const [exportURL, setExportURL] = useRecoilState(exportUrlState);
+  const [exportURLDisplay, setExportURLDisplay] = useState('');
+  const [hasValidURL, setHasValidURL] = useState<boolean>(true);
+  
+  function checkURL(urlStr: string) {
+    // This is a bit more debated than I expected. I think we need port matching, so this regex might work from comments here: 
+    // https://stackoverflow.com/questions/161738/what-is-the-best-regular-expression-to-check-if-a-string-is-a-valid-url
+    // does not require http protocol
+    // const regex = new RegExp(/((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+(:[0-9]+)?|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))?)/);
+    // make boolean
+    // (TODO: don't allow spaces?)
+    // return !!urlStr.match(regex);
+
+    // non-regex approach - depends on what we're trying to match on, but this seems more consistent
+    // https://stackoverflow.com/questions/5717093/check-if-a-javascript-string-is-a-url
+    // requires http protocol
+    let url;
+    try {
+      url = new URL(urlStr);
+    } catch (_) {
+      return false;  
+    }
+    return url.protocol === "http:" || url.protocol === "https:";
+  }
+
+
   return (
     <TextInput
       placeholder="Export URL (Data Source)"
-      value={exportURL}
-      onChange={event => setExportURL(event.currentTarget.value)}
+      value={exportURLDisplay}
+      onChange={
+        (event) => {
+          const valid = checkURL(event.currentTarget.value);
+          setHasValidURL(valid);
+          setExportURLDisplay(event.currentTarget.value);
+          if (valid){
+            // only update shared state if valid
+            setExportURL(event.currentTarget.value);
+          } else{
+            // else share empty state
+            setExportURL('');
+          }
+          
+        }
+      }
+      error={hasValidURL ? undefined : <>Valid URL required</> }
     />
   );
 }

--- a/components/ExportURLInput.tsx
+++ b/components/ExportURLInput.tsx
@@ -1,12 +1,9 @@
 import { TextInput } from '@mantine/core';
 import { exportUrlState } from '../state/atoms/exportUrl';
-import { useState } from 'react';
 import { useRecoilState } from 'recoil';
 
 export default function ExportURLInput() {
   const [exportURL, setExportURL] = useRecoilState(exportUrlState);
-  const [exportURLDisplay, setExportURLDisplay] = useState('');
-  const [hasValidURL, setHasValidURL] = useState<boolean>(true);
   
   function checkURL(urlStr: string) {
     // This is a bit more debated than I expected. I think we need port matching, so this regex might work from comments here: 
@@ -33,23 +30,17 @@ export default function ExportURLInput() {
   return (
     <TextInput
       placeholder="Export URL (Data Source)"
-      value={exportURLDisplay}
+      value={exportURL.url}
       onChange={
         (event) => {
           const valid = checkURL(event.currentTarget.value);
-          setHasValidURL(valid);
-          setExportURLDisplay(event.currentTarget.value);
-          if (valid){
-            // only update shared state if valid
-            setExportURL(event.currentTarget.value);
-          } else{
-            // else share empty state
-            setExportURL('');
-          }
-          
+          setExportURL({
+              url: event.currentTarget.value,
+              valid: valid
+            });
         }
       }
-      error={hasValidURL ? undefined : <>Valid URL required</> }
+      error={exportURL.valid ? undefined : <>Valid URL required</> }
     />
   );
 }

--- a/state/atoms/exportUrl.ts
+++ b/state/atoms/exportUrl.ts
@@ -4,7 +4,10 @@ import { atom } from 'recoil';
  * Atom tracking and controlling the value of export URL
  * entered for bulk submit by the user
  */
-export const exportUrlState = atom({
+export const exportUrlState = atom<{ url: string; valid: boolean }>({
   key: 'exportUrlState',
-  default: ''
+  default: {
+    url: '',
+    valid: true
+  }
 });

--- a/state/selectors/kickoffRequest.ts
+++ b/state/selectors/kickoffRequest.ts
@@ -15,8 +15,8 @@ export const kickoffRequestState = selector<KickoffRequestData | null>({
     const selectedMeasure = get(selectedMeasureState);
     const exportUrl = get(exportUrlState);
 
-    if (selectedMeasure && exportUrl) {
-      return buildKickoffRequest(selectedMeasure, exportUrl);
+    if (selectedMeasure && exportUrl.url && exportUrl.valid) {
+      return buildKickoffRequest(selectedMeasure, exportUrl.url);
     } else {
       return null;
     }


### PR DESCRIPTION
## Summary

Add validation of the export URL.

### New Behavior
The export URL must validate as a URL according to javascript URL creation requirements (if we really want a regex instead, there are some comments about regex-ing in the code that can otherwise be removed).
If the string input does not validate as a URL, the input box text is highlighted red and an error message indicates that a "Valid URL is required". Additionally, the URL must be validated to show the request body in the Kickoff Request Panel. A valid URL is automatically populated into the Kickoff Request Body.

### Code Changes
- ExportURLInput has a url validation function used to update the state and add any error
- ExportURL atom updated to share validation state (to update the KickoffRequestBody accordingly)
- kickOffRequest selector checks export url validation before building request
- ExportURLInput tests for validation
- ResetInputsButton test update to check the actual textbox content (to catch the way I initially broke it) and updates for the new state

## Testing Guidance
run `npm test`
Load the app and try various URLs in the export url text box. Try with a measure selected. Try resetting the app inputs. Note that an http protocol URL is expected. Try to make break?